### PR TITLE
Github Login API 연동 및 User 조회/수정

### DIFF
--- a/src/main/java/kr/co/nogibackend/interfaces/user/LoginController.java
+++ b/src/main/java/kr/co/nogibackend/interfaces/user/LoginController.java
@@ -14,6 +14,13 @@ import kr.co.nogibackend.domain.user.dto.info.UserLoginByGithubInfo;
 import kr.co.nogibackend.response.service.Response;
 import lombok.RequiredArgsConstructor;
 
+/*
+  Package Name : kr.co.nogibackend.interfaces.user
+  File Name    : LoginController
+  Author       : won taek oh
+  Created Date : 25. 2. 14.
+  Description  :
+ */
 @RestController
 @RequiredArgsConstructor
 public class LoginController {

--- a/src/main/java/kr/co/nogibackend/interfaces/user/UserController.java
+++ b/src/main/java/kr/co/nogibackend/interfaces/user/UserController.java
@@ -15,6 +15,13 @@ import kr.co.nogibackend.interfaces.user.dto.UserUpdateRequest;
 import kr.co.nogibackend.response.service.Response;
 import lombok.RequiredArgsConstructor;
 
+/*
+  Package Name : kr.co.nogibackend.interfaces.user
+  File Name    : UserController
+  Author       : won taek oh
+  Created Date : 25. 2. 14.
+  Description  :
+ */
 @RestController
 @RequestMapping("/users")
 @RequiredArgsConstructor


### PR DESCRIPTION
※ commits 보면 내용이 없는데 실수로 merge 처버렸음...ㅎ
# 📌 주요 변경점
- User Role 추가
- Github Login 연동
- Jwt Filter 처리
- User 수정/단건 조회

## 🛡️Github 로그인 시 저장소 삭제 권한은 없음!
- 기존에 저장소 삭제 권한 받는줄 알았지만 삭제 권한없음
- `scope` 라는 파라미터를 url 에 두어서 권한을 제어하는데 아래와같이 scope 를 설정해둠
  - `public_repo` : Public Repo 쓰기 권한(Issue, PR, Commit 도 포함)
  - `user:email` : 사용자의 email 정보를 조회(커밋할 때 사용)

## ✅ NOGI_BOT 을 위한 User Role 추가
- 메서드 중에 `findNogiBot` 메서드가 있는데 이를 통해 알림 처리할 때 사용할 NOGI_BOT 토큰을 가져옴
- DB에 없을 경우 꼭 넣어주어야함(github_access_token, role 만 넣어주면됨)
- 일단 prod DB 에 inert 해둠

## ➡️ Github Login 프로세스(‼️중요‼️)
```
- [프로세스 참고한 블로그](https://datamoney.tistory.com/336)

- nogi-bot 계정으로 앱을 생성해둠( `Settings` -> `Developer Settings` -> `OAuth Apps` -> `nogi`)
- 다른건 건드릴건 없고, 아래쪽에 `Authorization callback URL` 를 잘 설정해야함
  - 이 값이 유저가 github login 화면에서 로그인하면 api 서버에서 code 를 받는 경로임
  - LoginController 의 GET `login/code/github` 를 보면 로직이 있음
- 현재 로그인 버튼을 눌렀을 때 구상한 로직은 아래와 같음
```
### 1. 프론트에서 github 로그인 페이지에 접속할 수 있는 URL 을 가져온다.
  - GET `github/auth-url` 를 통해 받도록함(수정될 가능성이 높아서 back에서 가져오기로함)
### 2. 1번으로 가져온 url 로 프론트에서 location을 이동한다. 
```javascript
const onLogin = () => {
  // axios 로 back 에 url 요청
  const githubAuthUrl = `${백에서 받은 url}`;
  window.location.href = githubAuthUrl; // GitHub 로그인 페이지로 이동
};
```
### 3. 유저가 github login 화면에서 로그인을 한다.

### 4. api 서버에서 callback URL 의 경로로 code 값을 받는다.

### 5. 아래 과정을 진행한다.(UserFacade 의 loginByGithub 메서드)
   1. access token 가져오기
   2. user 정보 가져오기
   3. user 정보 저장하기
   4. access toekn 발급하기(nogi token)

### 6. 다시 redirect를 한다.
  - 참고 이미지(조금 다름 아래서 설명함)
![image](https://github.com/user-attachments/assets/f6daa832-707b-442f-a589-5c9f22e78022)
  - 이 때 redirectUrl 을 back end 에서 제어 한다.
  - redirecUrl 은 따로 프론트에 따로 페이지를 만들어서 다시 이동하고 싶은 페이지로 프론트에서 제어해서 보낸다.
  - 파라미터로 아래 정보를 보낸다.
     - `accessToken `: 쿠키에 담을지 로컬에 저장할지 고민 중
     - `requireUserInfo` : 이 값이 true 일 경우 내정보 페이지로 이동할 수 있도록 프론트에서 처리하기
     - `userId` : 혹시 몰라서 넣은 값
  - 이미지에는 현재 로그인 성공/실패로 분기를 태워서 router.push 를 하고 있지만 nogi 에서는 requireUserInfo 값에 따라 다른게 분기를 태우면 된다.

## Jwt Filter 처리
- `config/security` 하위 폴더에 관련 클래스들이 있음
- 필터를 적용하지 않을 uri 을 추가하고 싶을 경우 JwtAuthenticationFilter 클래스에서 EXCLUDED_URLS 에 추가하면됨

## 👤 User 수정 처리
- 내 정보 페이지에서 사용할 조회/수정 API 개발함(테스트 못하긴함...ㅎ)
- 수정 API 는 아래와같은 분기로 처리됨
  - user 를 조회한다.
  - user 에 저장소(githubRepository) 가 없거나 저장소의 이름이 바뀌었을 경우 github repo 에 알림을 보낸다.
  - user 정보들을 수정 한다.

